### PR TITLE
fix(usdc): use USD Coin as name

### DIFF
--- a/src/AstriaBridgeableUSDC.sol
+++ b/src/AstriaBridgeableUSDC.sol
@@ -30,7 +30,7 @@ contract AstriaBridgeableUSDC is IAstriaWithdrawer, ERC20 {
         uint256 _sequencerWithdrawalFee,
         uint256 _ibcWithdrawalFee,
         address _feeRecipient
-    ) ERC20("USDC", "USDC") Ownable(msg.sender) {
+    ) ERC20("USD Coin", "USDC") Ownable(msg.sender) {
         if (_baseChainAssetPrecision > decimals()) {
             revert("AstriaBridgeableUSDC: base chain asset precision must be less than or equal to token decimals");
         }


### PR DESCRIPTION
Based on looking at previous ERC20 USDC deployments, this is the naming used.